### PR TITLE
Update template.json

### DIFF
--- a/Hands-on lab/AzureTemplate/template.json
+++ b/Hands-on lab/AzureTemplate/template.json
@@ -703,7 +703,7 @@
         "typeHandlerVersion": "2.19",
         "autoUpgradeMinorVersion": true,
         "settings": {
-          "ModulesUrl": "https://github.com/MCW-Azure-security-privacy-and-compliance/blob/master/Hands-on%20lab/Scripts/Install_IIS.zip?raw=true",
+          "ModulesUrl": "https://github.com/Microsoft/MCW-Azure-security-privacy-and-compliance/blob/master/Hands-on%20lab/Scripts/Install_IIS.zip?raw=true",
           "ConfigurationFunction": "Install_IIS.ps1\\InstallIIS",
           "Properties": {
             "MachineName": "web-1"


### PR DESCRIPTION
The previous path used for DSC has changed and causes the ARM deployment to fail. This proposed change provides the current path to the file.